### PR TITLE
Use default ES version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,6 @@ export default function renameExtensions(
                 if (file.code) {
                     const magicString = new MagicString(file.code);
                     const ast = this.parse(file.code, {
-                        ecmaVersion: 6,
                         sourceType: 'module',
                     });
 


### PR DESCRIPTION
Hardcoding Acorn's ES version to 6 prevents this plugin from parsing language features like `async`/`await`. The ES version could be made into a configuration option, but I'm not sure what the use case would be.

By default Acorn currently parses ES2018.